### PR TITLE
Update spin lock leave method

### DIFF
--- a/JavaScript/7-spin-lock.js
+++ b/JavaScript/7-spin-lock.js
@@ -31,7 +31,6 @@ class Mutex {
   leave() {
     if (!this.owner) return;
     Atomics.store(this.lock, 0, UNLOCKED);
-    Atomics.notify(this.lock, 0, 1);
     this.owner = false;
   }
 }


### PR DESCRIPTION
Looks like a redundant line, because of we don't use either Atomics.wait and Atomics.waitAsync