### PR TITLE
Enhance livelock example

### DIFF
--- a/JavaScript/3-livelock.js
+++ b/JavaScript/3-livelock.js
@@ -3,6 +3,8 @@
 const threads = require('node:worker_threads');
 const { Worker, isMainThread } = threads;
 
+const THREADS_COUNT = 7;
+
 const LOCKED = 0;
 const UNLOCKED = 1;
 
@@ -37,24 +39,49 @@ if (isMainThread) {
   const mutex1 = new Mutex(buffer, 0, true);
   const mutex2 = new Mutex(buffer, 4, true);
   console.dir({ mutex1, mutex2 });
-  new Worker(__filename, { workerData: buffer });
-  new Worker(__filename, { workerData: buffer });
+  for (let i = 0; i < THREADS_COUNT; i++) new Worker(__filename, { workerData: buffer });
 } else {
   const { threadId, workerData } = threads;
   const mutex1 = new Mutex(workerData);
   const mutex2 = new Mutex(workerData, 4);
 
-  const loop = () => {
+  const lowFrequencyLoop = (delay) => {
+    mutex1.enter(() => {
+      console.log(`Some useful processing from worker${threadId} based on data locked by mutex1`);
+      mutex2.enter(() => {
+        console.log(`Some useful processing from worker${threadId} based on data locked by mutex2`);
+        setTimeout(() => {
+          mutex1.leave();
+          console.log(`Left mutex1 from worker${threadId} after some useful process has been done`);
+          mutex2.leave();
+          console.log(`Left mutex2 from worker${threadId} after some useful process has been done`);
+          setTimeout(lowFrequencyLoop, delay, delay);
+        }, 2000);
+      });
+    });
+  };
+
+  const highFrequencyLoop = (delay) => {
     mutex1.enter(() => {
       console.log(`Entered mutex1 from worker${threadId}`);
-      if (mutex1.leave()) console.log(`Left mutex1 from worker${threadId}`);
+      mutex1.leave();
+      console.log(`Left mutex1 from worker${threadId}`);
     });
     mutex2.enter(() => {
       console.log(`Entered mutex2 from worker${threadId}`);
-      if (mutex2.leave()) console.log(`Left mutex2 from worker${threadId}`);
+      mutex2.leave();
+      console.log(`Left mutex2 from worker${threadId}`);
     });
-    setTimeout(loop, 0);
+    setTimeout(highFrequencyLoop, delay, delay);
   };
-  loop();
 
+  if (threadId === THREADS_COUNT) {
+    // Only one thread executes low frequent process
+    lowFrequencyLoop(1000);
+  } else {
+    // All other threads executes high frequent processes
+    highFrequencyLoop(100);
+    // Try to change delay between iterations to 1 ms
+    // Look out how livelock preventing useful low frequent process to get access on data locked by Mutex
+  }
 }


### PR DESCRIPTION
In the video chapter related to [`3-livelock.js` example](https://youtu.be/JNLrITevhRI?t=3728) there is no clear evidence what livelock is and how you may notice it by that example. Had noticed in the comment section that I'm not the only one who mention that.

Current `3-livelock.js` example in this repository contains looping recursion that useless by code itself. In other words there is no state that you may compare as normal working processes in difference to livelock.

I propose to extend usage example. It becomes more complex but clear to notice livelock and test the difference:
- 7 threads
- 6 of it executes high frequency loop (the same as in the current repository state)
- last 7th thread executes low frequency loop with long running process (being long running isn't necessary but that way more easy to notice the complete execution of it)
- initial 10 times frequency difference do not lead to livelock (at least on the level between high and low frequency processes, excluding the possibility of livelock among 6 high frequency ones)
- comment with proposal to make frequency difference 100 times higher which will lead to livelock on both levels (possible `highFrequencyLoop` inconsistency and starvation of the `lowFrequencyLoop`).

Please review my proposal because I'm not an expert in parallel programming. The articles on the topic of livelock in the internet are quite confusing and controversial. The most well explained that I've found is [Deadlock, Livelock and Starvation](https://www.baeldung.com/cs/deadlock-livelock-starvation). I'm trying to figure out how to make more clear and evident test but realizes that my understanding might be wrong.